### PR TITLE
Add "v" prefix to changelog generation regex

### DIFF
--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Create changelog
         uses: arduino/create-changelog@v1
         with:
-          tag-regex: '^[0-9]+\.[0-9]+\.[0-9]+.*$'
+          tag-regex: '^v?[0-9]+\.[0-9]+\.[0-9]+.*$'
           filter-regex: '^\[(skip|changelog)[ ,-](skip|changelog)\].*'
           case-insensitive-regex: true
           changelog-file-path: "${{ env.DIST_DIR }}/CHANGELOG.md"


### PR DESCRIPTION
The repository's existing tags use the style where the name is identical to the version name. The [`arduino/create-changelog` action's `tag-regex` input](https://github.com/arduino/create-changelog#inputs) value is currently configured for this tag style. That is correct for the previous tags, but all future tags will use the "v" prefix, as is required for best practices use of the project as a Go module dependency. This will result in the generated changelog for future releases containing the repository's commit history back to the last tag that uses the non-"v" prefix style of tag.

Setting the regex up to support both tag styles will avoid such an issue.

---
Demo release using the updated workflow: https://github.com/per1234/mdns-discovery/releases/tag/v1.4.2