### PR TITLE
Changed mdns library to fix IPv6 issues on OS X

### DIFF
--- a/.licenses/mdns-discovery/go/github.com/arduino/mdns.dep.yml
+++ b/.licenses/mdns-discovery/go/github.com/arduino/mdns.dep.yml
@@ -1,9 +1,9 @@
 ---
-name: github.com/hashicorp/mdns
-version: v1.0.4
+name: github.com/arduino/mdns
+version: v1.0.5-0.20211124112247-3bf2ec2117c5
 type: go
 summary: 
-homepage: https://pkg.go.dev/github.com/hashicorp/mdns
+homepage: https://pkg.go.dev/github.com/arduino/mdns
 license: mit
 licenses:
 - sources: LICENSE

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,6 @@ go 1.16
 require (
 	github.com/arduino/go-paths-helper v1.6.1 // indirect
 	github.com/arduino/go-properties-orderedmap v1.5.0
+	github.com/arduino/mdns v1.0.5-0.20211124112247-3bf2ec2117c5
 	github.com/arduino/pluggable-discovery-protocol-handler v1.2.0
-	github.com/hashicorp/mdns v1.0.4
 )

--- a/go.sum
+++ b/go.sum
@@ -4,12 +4,12 @@ github.com/arduino/go-paths-helper v1.6.1/go.mod h1:V82BWgAAp4IbmlybxQdk9Bpkz8M4
 github.com/arduino/go-properties-orderedmap v1.4.0/go.mod h1:DKjD2VXY/NZmlingh4lSFMEYCVubfeArCsGPGDwb2yk=
 github.com/arduino/go-properties-orderedmap v1.5.0 h1:istmr13qQN3nneuU3lsqlMvI6jqB3u8QUfVU1tX/t/8=
 github.com/arduino/go-properties-orderedmap v1.5.0/go.mod h1:DKjD2VXY/NZmlingh4lSFMEYCVubfeArCsGPGDwb2yk=
+github.com/arduino/mdns v1.0.5-0.20211124112247-3bf2ec2117c5 h1:fbhij4dK/w6KocjReBg48O6UuyRSLo31Xl1mYq1JyGc=
+github.com/arduino/mdns v1.0.5-0.20211124112247-3bf2ec2117c5/go.mod h1:mo3tCC9kw/TYfyrZ1TcsGozoy6CFe+GXPvyoEfZDLIY=
 github.com/arduino/pluggable-discovery-protocol-handler v1.2.0 h1:gw6W8CtgGc+kh+DKfh+z6cUVPqaZh9Tu3XCt/uGgJUE=
 github.com/arduino/pluggable-discovery-protocol-handler v1.2.0/go.mod h1:vQfYGJnunfcscLoUcZKqJBlEkZ/qiE28TQj+RV9UT74=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/hashicorp/mdns v1.0.4 h1:sY0CMhFmjIPDMlTB+HfymFHCaYLhgifZ0QhjaYKD/UQ=
-github.com/hashicorp/mdns v1.0.4/go.mod h1:mtBihi+LeNXGtG8L9dX59gAEa12BDtBQSp4v/YAJqrc=
 github.com/miekg/dns v1.1.41 h1:WMszZWJG0XmzbK9FEmzH2TVcqYzFesusSIB41b8KHxY=
 github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJysuI=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/main.go
+++ b/main.go
@@ -28,8 +28,8 @@ import (
 	"time"
 
 	properties "github.com/arduino/go-properties-orderedmap"
+	"github.com/arduino/mdns"
 	discovery "github.com/arduino/pluggable-discovery-protocol-handler"
-	"github.com/hashicorp/mdns"
 )
 
 func main() {
@@ -126,6 +126,7 @@ func (d *MDNSDiscovery) StartSync(eventCB discovery.EventCallback, errorCB disco
 		Timeout:             discoveryInterval,
 		Entries:             queriesChan,
 		WantUnicastResponse: false,
+		DisableIPv6:         true,
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
I changed the `mdns` library in use from `github.com/hashicorp/mdns` to our forked version `github.com/arduino/mdns` one. 

Our fork integrates the hashicorp/mdns#84 PR giving us the chance to fully disable IPv6, this way we avoid errors when it's not supported by the network.

```{
  "eventType": "start_sync",
  "error": true,
  "message": "mdns lookup error: write udp6 [::]:53182-\u003e[ff02::fb]:5353: sendto: no route to host"
}
{
  "eventType": "start_sync",
  "error": true,
  "message": "mdns lookup error: write udp6 [::]:51040-\u003e[ff02::fb]:5353: sendto: no route to host"
}
{
  "eventType": "start_sync",
  "error": true,
  "message": "mdns lookup error: write udp6 [::]:55141-\u003e[ff02::fb]:5353: sendto: no route to host"
}```