### PR TITLE
Remove forked dependencies in favor of original library

### DIFF
--- a/.licenses/mdns-discovery/go/github.com/hashicorp/mdns.dep.yml
+++ b/.licenses/mdns-discovery/go/github.com/hashicorp/mdns.dep.yml
@@ -1,9 +1,9 @@
 ---
-name: github.com/arduino/mdns
-version: v1.0.5-0.20211124112247-3bf2ec2117c5
+name: github.com/hashicorp/mdns
+version: v1.0.5
 type: go
 summary: 
-homepage: https://pkg.go.dev/github.com/arduino/mdns
+homepage: https://pkg.go.dev/github.com/hashicorp/mdns
 license: mit
 licenses:
 - sources: LICENSE

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.16
 
 require (
 	github.com/arduino/go-properties-orderedmap v1.6.0
-	github.com/arduino/mdns v1.0.5-0.20211124112247-3bf2ec2117c5
 	github.com/arduino/pluggable-discovery-protocol-handler/v2 v2.0.2
+	github.com/hashicorp/mdns v1.0.5
 )

--- a/go.sum
+++ b/go.sum
@@ -53,8 +53,6 @@ github.com/arduino/go-properties-orderedmap v1.6.0 h1:gp2JoWRETtqwsZ+UHu/PBuYWYH
 github.com/arduino/go-properties-orderedmap v1.6.0/go.mod h1:DKjD2VXY/NZmlingh4lSFMEYCVubfeArCsGPGDwb2yk=
 github.com/arduino/go-timeutils v0.0.0-20171220113728-d1dd9e313b1b/go.mod h1:uwGy5PpN4lqW97FiLnbcx+xx8jly5YuPMJWfVwwjJiQ=
 github.com/arduino/go-win32-utils v0.0.0-20180330194947-ed041402e83b/go.mod h1:iIPnclBMYm1g32Q5kXoqng4jLhMStReIP7ZxaoUC2y8=
-github.com/arduino/mdns v1.0.5-0.20211124112247-3bf2ec2117c5 h1:fbhij4dK/w6KocjReBg48O6UuyRSLo31Xl1mYq1JyGc=
-github.com/arduino/mdns v1.0.5-0.20211124112247-3bf2ec2117c5/go.mod h1:mo3tCC9kw/TYfyrZ1TcsGozoy6CFe+GXPvyoEfZDLIY=
 github.com/arduino/pluggable-discovery-protocol-handler/v2 v2.0.2 h1:r9O2SF838OeYiUoI+/Ruo8GFlnHWA61BhzFphduA6Z0=
 github.com/arduino/pluggable-discovery-protocol-handler/v2 v2.0.2/go.mod h1:5YzA/5e6PfTkmlNZ8bbqftqxF0EEVOCRVXuQ0341WOY=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
@@ -187,6 +185,8 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hashicorp/logutils v1.0.0/go.mod h1:QIAnNjmIWmVIIkWDTG1z5v++HQmx9WQRO+LraFDTW64=
 github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0mNTz8vQ=
+github.com/hashicorp/mdns v1.0.5 h1:1M5hW1cunYeoXOqHwEb/GBDDHAFo0Yqb/uz/beC6LbE=
+github.com/hashicorp/mdns v1.0.5/go.mod h1:mtBihi+LeNXGtG8L9dX59gAEa12BDtBQSp4v/YAJqrc=
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/main.go
+++ b/main.go
@@ -28,8 +28,8 @@ import (
 	"time"
 
 	properties "github.com/arduino/go-properties-orderedmap"
-	"github.com/arduino/mdns"
 	discovery "github.com/arduino/pluggable-discovery-protocol-handler/v2"
+	"github.com/hashicorp/mdns"
 )
 
 func main() {


### PR DESCRIPTION
Remove dependency to forked [`github.com/arduino/mdns`](https://github.com/arduino/mdns) in favor of the original [`github.com/hashicorp/mdns`](https://github.com/hashicorp/mdns) after hashicorp/mdns#84 has been merged.

Fixes #16.