### PR TITLE
Port address label is now formatted in a better way

### DIFF
--- a/main.go
+++ b/main.go
@@ -213,9 +213,19 @@ func toDiscoveryPort(entry *mdns.ServiceEntry) *discovery.Port {
 		}
 	}
 
+	var name string
+	if split := strings.Split(entry.Host, "."); len(split) > 0 {
+		// Use the first part of the entry host name to display
+		// the address label
+		name = split[0]
+	} else {
+		// Fallback
+		name = entry.Name
+	}
+
 	return &discovery.Port{
 		Address:       ip,
-		AddressLabel:  fmt.Sprintf("%s at %s", entry.Name, ip),
+		AddressLabel:  fmt.Sprintf("%s at %s", name, ip),
 		Protocol:      "network",
 		ProtocolLabel: "Network Port",
 		Properties:    props,


### PR DESCRIPTION
This PR changes the `label` field of all events returned by `mdns-discovery`. 

Previously it would use the event's name received from the library used internally, now it uses the hostname to build a more readable one.

Previous output: 
```
{
  "eventType": "add",
  "port": {
    "address": "10.130.22.94",
    "label": "Waltz._companion-link._tcp.local. at 10.130.22.94",
    "protocol": "network",
    "protocolLabel": "Network Port",
    "properties": {
      "hostname": "waltz.local.",
      "port": "49949",
      "rpAD": "7cb09634a8a9",
      "rpBA": "AA:DE:47:C4:E5:98",
      "rpFl": "0x20000",
      "rpHA": "5f3e38f43228",
      "rpHI": "94bd919e64ea",
      "rpHN": "4f7e4d9fc3f5",
      "rpMac": "0",
      "rpVr": "330.5"
    }
  }
}
{
  "eventType": "add",
  "port": {
    "address": "10.130.22.107",
    "label": "Alberto\\226\\128\\153s\\ MacBook\\ Pro._companion-link._tcp.local. at 10.130.22.107",
    "protocol": "network",
    "protocolLabel": "Network Port",
    "properties": {
      "hostname": "Albertos-MacBook-Pro.local.",
      "port": "56523",
      "rpAD": "27e04ce2a824",
      "rpBA": "2E:87:10:65:A3:8E",
      "rpFl": "0x20000",
      "rpHA": "91287b2002f8",
      "rpHI": "a4f728bc23e5",
      "rpHN": "7f38009a0a5c",
      "rpVr": "195.2"
    }
  }
}
{
  "eventType": "add",
  "port": {
    "address": "10.130.22.97",
    "label": "48:35:2b:b0:fd:00\\@fe80::4a35:2bff:feb0:fd00._apple-mobdev2._tcp.local. at 10.130.22.97",
    "protocol": "network",
    "protocolLabel": "Network Port",
    "properties": {
      "hostname": "Daedalus-2.local.",
      "port": "32498"
    }
  }
}
{
  "eventType": "add",
  "port": {
    "address": "10.130.22.110",
    "label": "V\\.Rubino\\ MacBook\\ Pro._companion-link._tcp.local. at 10.130.22.110",
    "protocol": "network",
    "protocolLabel": "Network Port",
    "properties": {
      "hostname": "VRubino-MacBook-Pro.local.",
      "port": "49182",
      "rpAD": "8d69c0272eac",
      "rpBA": "DE:BF:8E:A9:A6:66",
      "rpFl": "0x20000",
      "rpHA": "7a8a1ccbe370",
      "rpHI": "d086e991e5fb",
      "rpHN": "b0279f940ebf",
      "rpMac": "0",
      "rpVr": "260.3"
    }
  }
}
```

New output:

```
{
  "eventType": "add",
  "port": {
    "address": "10.130.22.94",
    "label": "waltz at 10.130.22.94",
    "protocol": "network",
    "protocolLabel": "Network Port",
    "properties": {
      "hostname": "waltz.local.",
      "port": "49949",
      "rpAD": "7cb09634a8a9",
      "rpBA": "AA:DE:47:C4:E5:98",
      "rpFl": "0x20000",
      "rpHA": "5f3e38f43228",
      "rpHI": "94bd919e64ea",
      "rpHN": "4f7e4d9fc3f5",
      "rpMac": "0",
      "rpVr": "330.5"
    }
  }
}
{
  "eventType": "add",
  "port": {
    "address": "10.130.22.107",
    "label": "Albertos-MacBook-Pro at 10.130.22.107",
    "protocol": "network",
    "protocolLabel": "Network Port",
    "properties": {
      "hostname": "Albertos-MacBook-Pro.local.",
      "port": "56523",
      "rpAD": "27e04ce2a824",
      "rpBA": "2E:87:10:65:A3:8E",
      "rpFl": "0x20000",
      "rpHA": "91287b2002f8",
      "rpHI": "a4f728bc23e5",
      "rpHN": "7f38009a0a5c",
      "rpVr": "195.2"
    }
  }
}
{
  "eventType": "add",
  "port": {
    "address": "10.130.22.97",
    "label": "Daedalus-2 at 10.130.22.97",
    "protocol": "network",
    "protocolLabel": "Network Port",
    "properties": {
      "hostname": "Daedalus-2.local.",
      "port": "32498"
    }
  }
}
{
  "eventType": "add",
  "port": {
    "address": "10.130.22.110",
    "label": "VRubino-MacBook-Pro at 10.130.22.110",
    "protocol": "network",
    "protocolLabel": "Network Port",
    "properties": {
      "hostname": "VRubino-MacBook-Pro.local.",
      "port": "49182",
      "rpAD": "8d69c0272eac",
      "rpBA": "DE:BF:8E:A9:A6:66",
      "rpFl": "0x20000",
      "rpHA": "7a8a1ccbe370",
      "rpHI": "d086e991e5fb",
      "rpHN": "b0279f940ebf",
      "rpMac": "0",
      "rpVr": "260.3"
    }
  }
}
```