### PR TITLE
Query for every available interface

### DIFF
--- a/main.go
+++ b/main.go
@@ -69,7 +69,7 @@ var ipv6Addr = &net.UDPAddr{
 }
 
 // QueryParam{} has to select which IP version(s) to use
-type Connectivity struct {
+type connectivity struct {
 	IPv4 bool
 	IPv6 bool
 }
@@ -166,7 +166,7 @@ func (d *MDNSDiscovery) StartSync(eventCB discovery.EventCallback, errorCB disco
 func queryLoop(ctx context.Context, queriesChan chan<- *mdns.ServiceEntry) {
 	for {
 		var interfaces []net.Interface
-		var conn Connectivity
+		var conn connectivity
 		var wg sync.WaitGroup
 
 		interfaces, err := availableInterfaces()
@@ -199,17 +199,17 @@ func queryLoop(ctx context.Context, queriesChan chan<- *mdns.ServiceEntry) {
 	}
 }
 
-func (conn *Connectivity) available() bool {
+func (conn *connectivity) available() bool {
 	return conn.IPv4 || conn.IPv6
 }
 
-func checkConnectivity() Connectivity {
+func checkConnectivity() connectivity {
 	// We must check if we're connected to a local network, if we don't
 	// the subsequent mDNS query would fail and return an error.
 	// If we managed to open a connection close it, mdns.Query opens
 	// another one on the same IP address we use and it would fail
 	// if we leave this open.
-	out := Connectivity{
+	out := connectivity{
 		IPv4: true,
 		IPv6: true,
 	}
@@ -265,7 +265,7 @@ func availableInterfaces() ([]net.Interface, error) {
 	return out, nil
 }
 
-func makeQueryParams(netif *net.Interface, conn Connectivity, queriesChan chan<- *mdns.ServiceEntry) (params *mdns.QueryParam) {
+func makeQueryParams(netif *net.Interface, conn connectivity, queriesChan chan<- *mdns.ServiceEntry) (params *mdns.QueryParam) {
 	return &mdns.QueryParam{
 		Service:             mdnsServiceName,
 		Domain:              "local",

--- a/main.go
+++ b/main.go
@@ -54,7 +54,7 @@ const portsTTL = time.Second * 60
 const queryInterval = time.Second * 30
 
 // mdns.Query() will either exit early or timeout after this amount of time
-const discoveryTimeout = time.Second * 15
+const queryTimeout = time.Second * 15
 
 // IP address used to check if we're connected to a local network
 var ipv4Addr = &net.UDPAddr{
@@ -240,9 +240,7 @@ func availableInterfaces() ([]net.Interface, error) {
 	}
 
 	var out []net.Interface
-	for n := range interfaces {
-		netif := interfaces[n]
-
+	for _, netif := range interfaces {
 		if netif.Flags&net.FlagUp == 0 {
 			continue
 		}
@@ -269,7 +267,7 @@ func makeQueryParams(netif *net.Interface, conn connectivity, queriesChan chan<-
 	return &mdns.QueryParam{
 		Service:             mdnsServiceName,
 		Domain:              "local",
-		Timeout:             discoveryTimeout,
+		Timeout:             queryTimeout,
 		Interface:           netif,
 		Entries:             queriesChan,
 		WantUnicastResponse: false,

--- a/main.go
+++ b/main.go
@@ -175,7 +175,7 @@ func queryLoop(ctx context.Context, queriesChan chan<- *mdns.ServiceEntry) {
 		}
 
 		conn = checkConnectivity()
-		if conn.available() {
+		if !conn.available() {
 			goto NEXT
 		}
 

--- a/main.go
+++ b/main.go
@@ -182,10 +182,11 @@ func queryLoop(ctx context.Context, queriesChan chan<- *mdns.ServiceEntry) {
 		wg.Add(len(interfaces))
 
 		for n := range interfaces {
-			go func(params *mdns.QueryParam) {
+			params := makeQueryParams(&interfaces[n], conn, queriesChan)
+			go func() {
 				defer wg.Done()
 				mdns.Query(params)
-			}(makeQueryParams(&interfaces[n], conn, queriesChan))
+			}()
 		}
 
 		wg.Wait()


### PR DESCRIPTION
resolving https://github.com/arduino/mdns-discovery/issues/25#issuecomment-1182464221 issue on Windows, `list` finally returns available boards instead of nothing
receiving end stays the same, sendQuery uses specific `Interface` to send things

not really sure about
- what errorCB supposed to do when **one** interface fails, but the rest don't
- what happens when multiple interfaces return the same thing (e.g. lan wifi & ethernet)