### PR TITLE
Fix `Identify Prerelease` step in the release workflow

### DIFF
--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -88,11 +88,12 @@ jobs:
         run: |
           wget -q -P /tmp https://github.com/fsaintjacques/semver-tool/archive/3.2.0.zip
           unzip -p /tmp/3.2.0.zip semver-tool-3.2.0/src/semver >/tmp/semver && chmod +x /tmp/semver
-          if [[
+          if [[ \
             "$(
               /tmp/semver get prerel \
                 "${GITHUB_REF/refs\/tags\//}"
-            )"
+            )" != \
+            "" \
           ]]; then
             echo "IS_PRE=true" >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
The condition to identify a prerelease was recently split to reduce the length of the line, causing the workflow to fail throwing this error:
```
/home/runner/work/_temp/1435c811-653a-480e-bcf6-c38ae8bd5d7e.sh: line 7: unexpected token `newline', conditional binary operator expected
Error: Process completed with exit code 2.
```
Introducing some `\` inside the condition should fix this issue.