### PR TITLE
 fix mac binary not placed in a top level directory

### DIFF
--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -156,9 +156,7 @@ jobs:
           chmod +x "${{ env.PROJECT_NAME }}_osx_${{ matrix.artifact.name }}/${{ env.PROJECT_NAME }}"
           TAG="${GITHUB_REF/refs\/tags\//}"
           PACKAGE_FILENAME="${{ env.PROJECT_NAME }}_${TAG}_${{ matrix.artifact.path }}"
-          tar -czvf "$PACKAGE_FILENAME" \
-          -C "${{ env.PROJECT_NAME }}_osx_${{ matrix.artifact.name }}/" "${{ env.PROJECT_NAME }}" \
-          -C ../../ LICENSE.txt
+          tar -czvf "$PACKAGE_FILENAME" "${{ env.PROJECT_NAME }}_osx_${{ matrix.artifact.name }}"
           echo "PACKAGE_FILENAME=$PACKAGE_FILENAME" >> $GITHUB_ENV
 
       - name: Upload artifact


### PR DESCRIPTION
This PR fixes the mac binary not being placed in a top level directory as the other binaries.
Before:
```
$ curl -s https://downloads.arduino.cc/discovery/mdns-discovery/mdns-discovery_v1.0.9_macOS_64bit.tar.gz | tar zt
mdns-discovery
LICENSE.txt
```
After:
```
$ curl -s https://downloads.arduino.cc/discovery/mdns-discovery/mdns-discovery_v1.0.9_macOS_64bit.tar.gz | tar zt
mdns-discovery_osx_darwin_amd64/
mdns-discovery_osx_darwin_amd64/mdns-discovery
mdns-discovery_osx_darwin_amd64/LICENSE.txt
```

