### PR TITLE
Use more meaningful variable names in release workflows

### DIFF
--- a/.github/workflows/publish-go-tester-task.yml
+++ b/.github/workflows/publish-go-tester-task.yml
@@ -75,7 +75,7 @@ jobs:
 
   build:
     needs: package-name-prefix
-    name: Build ${{ matrix.os.name }}
+    name: Build ${{ matrix.os.artifact-name }}
     runs-on: ubuntu-latest
 
     strategy:
@@ -83,31 +83,31 @@ jobs:
         os:
           - task: Windows_32bit
             path: "*Windows_32bit.zip"
-            name: Windows_X86-32
+            artifact-name: Windows_X86-32
           - task: Windows_64bit
             path: "*Windows_64bit.zip"
-            name: Windows_X86-64
+            artifact-name: Windows_X86-64
           - task: Linux_32bit
             path: "*Linux_32bit.tar.gz"
-            name: Linux_X86-32
+            artifact-name: Linux_X86-32
           - task: Linux_64bit
             path: "*Linux_64bit.tar.gz"
-            name: Linux_X86-64
+            artifact-name: Linux_X86-64
           - task: Linux_ARMv6
             path: "*Linux_ARMv6.tar.gz"
-            name: Linux_ARMv6
+            artifact-name: Linux_ARMv6
           - task: Linux_ARMv7
             path: "*Linux_ARMv7.tar.gz"
-            name: Linux_ARMv7
+            artifact-name: Linux_ARMv7
           - task: Linux_ARM64
             path: "*Linux_ARM64.tar.gz"
-            name: Linux_ARM64
+            artifact-name: Linux_ARM64
           - task: macOS_64bit
             path: "*macOS_64bit.tar.gz"
-            name: macOS_64
+            artifact-name: macOS_64
           - task: macOS_ARM64
             path: "*macOS_ARM64.tar.gz"
-            name: macOS_ARM64
+            artifact-name: macOS_ARM64
 
     steps:
       - name: Checkout repository
@@ -130,7 +130,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           path: ${{ env.DIST_DIR }}/${{ matrix.os.path }}
-          name: ${{ matrix.os.name }}
+          name: ${{ matrix.os.artifact-name }}
 
   checksums:
     needs:

--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        os:
+        task:
           - Windows_32bit
           - Windows_64bit
           - Linux_32bit
@@ -40,7 +40,7 @@ jobs:
 
       - name: Create changelog
         # Avoid creating the same changelog for each os
-        if: matrix.os == 'Windows_32bit'
+        if: matrix.task == 'Windows_32bit'
         uses: arduino/create-changelog@v1
         with:
           tag-regex: '^v?[0-9]+\.[0-9]+\.[0-9]+.*$'
@@ -55,7 +55,7 @@ jobs:
           version: 3.x
 
       - name: Build
-        run: task dist:${{ matrix.os }}
+        run: task dist:${{ matrix.task }}
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
GitHub Actions workflows are used to automatically generate beta tester and production builds of the project.

A separate build is generated for each of the target host types. This is done using a job matrix, which creates a parallel run of the workflow job for each target. The matrix defines variables that provide the data that is specific to each job.

The variable names used previously did not clearly communicate their nature:

- The variable for the task name was named `os`
- The variable for the workflow artifact was named `os.name`, which was a bit ambiguous

These variable names made it difficult for anyone not intimately familiar with the workings of the workflows to understand their code.