### PR TITLE
fix release action

### DIFF
--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -189,6 +189,7 @@ jobs:
     environment: production
     needs: notarize-macos
     permissions:
+      contents: write
       id-token: write # This is required for requesting the JWT
 
     steps:


### PR DESCRIPTION
fix ncipollo/release-action@v1 `Error 403: Resource not accessible by integration`

more details https://github.com/ncipollo/release-action/issues/208
followup of #67 