### PR TITLE
fix: skip virtual network adapters in availableInterfaces on Windows

### DIFF
--- a/main.go
+++ b/main.go
@@ -254,6 +254,49 @@ func availableInterfaces() ([]net.Interface, error) {
 			continue
 		}
 
+		// Skip virtual network adapters that are unlikely to have Arduino
+		// devices on them but cause multicast socket conflicts on Windows.
+		//
+		// When multiple interfaces each run an mdns.Query in parallel, Windows
+		// may deliver an incoming multicast UDP packet to only one of the
+		// competing sockets. If a virtual adapter's socket wins, the physical
+		// NIC's socket never sees the response, and discovery silently returns
+		// nothing even though the board is actively responding on the wire.
+		//
+		// Hyper-V virtual switches (WSL, Docker Desktop) are always named
+		// "vEthernet (...)" on Windows. VMware virtual adapters use "VMnet".
+		// These names are stable and controlled by their respective installers.
+		if strings.HasPrefix(netif.Name, "vEthernet") ||
+			strings.HasPrefix(netif.Name, "VMnet") {
+			continue
+		}
+
+		// Skip interfaces that have no routable unicast address.
+		// An interface with only a link-local address (169.254.x.x / fe80::)
+		// has no working DHCP lease and cannot reach real LAN devices.
+		// This also filters Linux/macOS virtual bridges (docker0, virbr0, etc.)
+		// that happen to have a MAC address but no reachable subnet.
+		addrs, err := netif.Addrs()
+		if err == nil {
+			hasRoutable := false
+			for _, addr := range addrs {
+				var ip net.IP
+				switch v := addr.(type) {
+				case *net.IPNet:
+					ip = v.IP
+				case *net.IPAddr:
+					ip = v.IP
+				}
+				if ip != nil && !ip.IsLinkLocalUnicast() && !ip.IsLoopback() {
+					hasRoutable = true
+					break
+				}
+			}
+			if !hasRoutable {
+				continue
+			}
+		}
+
 		out = append(out, netif)
 	}
 


### PR DESCRIPTION
On Windows with multiple network interfaces (WSL Hyper-V, Docker Desktop, VMware, VPN adapters), mdns-discovery queries all interfaces in parallel. Each query opens a UDP socket bound to 0.0.0.0:5353. When the target Arduino device sends its mDNS response, Windows delivers the incoming multicast packet to only one of the competing sockets — whichever the OS chooses internally. If a virtual adapter's socket wins, the physical NIC's socket never sees the packet and discovery silently returns nothing, even though the board is actively responding on the wire.

This was confirmed by network capture: the Arduino responded within 15 ms of the query, but ReadFromUDP was never called on the physical interface's socket. Disabling the WSL adapter (vEthernet) immediately fixed discovery.

Fix: filter out virtual adapters in availableInterfaces() so they are never queried:

- Skip interfaces named 'vEthernet*' (Hyper-V: WSL, Docker Desktop)
- Skip interfaces named 'VMnet*' (VMware)
- Skip interfaces with no routable unicast address (link-local only / 169.254.x.x) — catches Linux/macOS virtual bridges (docker0, virbr0) that have a MAC but no reachable LAN subnet

Interfaces that don't match any filter condition are queried exactly as before —
no behaviour change on machines with only physical adapters.

## Dependency

Boards might still not appear at all on Windows machines with virtual adapters unless the underlying
`hashicorp/mdns` multicast socket bug is also fixed. That bug causes
`ListenMulticastUDP` to join the multicast group on the wrong interface (the
virtual one, not the physical NIC), so responses from Arduino boards are never
received regardless of how many interfaces are queried.

A fix has been submitted upstream: https://github.com/hashicorp/mdns/pull/149

Until that is merged, `arduino/mdns-discovery` should apply the `replace`
directive in `go.mod` to use the patched fork, or absorb the one-line fix
directly. Without it, the multicast socket never sees the board's response on a
Windows machine with virtual adapters.  **It seems the hashicorp/mdns is not being actively maintained, so using the fork or creating a fork that is maintained specifically for arduino mdns might actually be the best way forward...** 

Fixes #87
Fixes #61