### PR TITLE
Fix/buffered queries channel

### DIFF
--- a/main.go
+++ b/main.go
@@ -145,7 +145,16 @@ func (d *MDNSDiscovery) StartSync(eventCB discovery.EventCallback, errorCB disco
 	// Query doesn't stop right away when we call d.Stop()
 	// neither we have to any to do it, we can only wait for it
 	// to return.
-	queriesChan := make(chan *mdns.ServiceEntry)
+	// Use a buffered channel so that simultaneous responses from multiple
+	// boards are not dropped. hashicorp/mdns sends entries with a non-blocking
+	// select (default: drop), so if the consumer goroutine has not yet read the
+	// previous entry the next one is silently lost.
+	//
+	// Note: the channel receives ALL mDNS entries seen on the multicast socket
+	// (not only Arduino ones — service-type filtering happens in toDiscoveryPort),
+	// so the buffer must accommodate every mDNS device that announces during the
+	// 15-second query window. 256 is large enough for any realistic LAN.
+	queriesChan := make(chan *mdns.ServiceEntry, 256)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	go func() {


### PR DESCRIPTION

### Title
fix: buffer queriesChan to prevent dropping simultaneous mDNS responses

### Body

## Problem

When two or more Arduino boards are on the same network, only one appears in
the Arduino IDE network port list. Which board is visible alternates randomly
between query cycles.

Related issues: #87, #61

## Root cause

`hashicorp/mdns` sends discovered service entries to the caller's channel using
a non-blocking select:

```go
select {
case params.Entries <- inp:
default:
}
```

If the consumer goroutine has not yet read the previous entry when the next one
arrives, the new entry hits the `default` branch and is **silently dropped**.

Multiple Arduino boards respond to the mDNS query almost simultaneously (typically
within 0.5ms of each other). Because `queriesChan` was unbuffered, only the first
response made it through per query cycle. Which board "won" depended entirely on
packet arrival order, causing the visible board to alternate unpredictably between
cycles.

This was confirmed via debug logging: both boards sent valid mDNS responses that
were received by the socket, but only one produced a `toDiscoveryPort` call — the
other was dropped before it reached the consumer.

## Fix

Create `queriesChan` with a buffer of 64 instead of unbuffered:

```go
queriesChan := make(chan *mdns.ServiceEntry, 64)
```

This ensures all simultaneous responses are queued regardless of consumer
scheduling. A buffer of 64 is large enough for any realistic number of Arduino
boards on a LAN.

## Testing

Verified on Windows with two Arduino UNO R4 Minima + W5500 boards on the same
network. Before the fix: only one board appeared per cycle (alternating between
which one was visible). After the fix: both boards appear consistently on every
cycle, from both a desktop PC and a laptop.

Note: this fix is complementary to the virtual interface filter fix in
PR fix/skip-virtual-interfaces-windows — that PR addresses Windows-specific
multicast socket conflicts, while this fix is cross-platform and affects anyone
with 2+ boards.